### PR TITLE
Add Supabase CRUD dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CastelColoTechnique
 
-Application React + TypeScript pour la gestion de l'équipe technique d'une colonie de vacances. Les données sont stockées dans Supabase.
+Application React + TypeScript pour la gestion de l'équipe technique d'une colonie de vacances. Toutes les données (agents, tâches, incidents…) sont maintenant stockées et mises à jour via Supabase.
 
 ## Configuration
 
@@ -24,3 +24,7 @@ npm run build
 ## Authentification
 
 La connexion se fait par email et mot de passe via Supabase. Seules les personnes enregistrées dans la base Supabase peuvent se connecter.
+
+## Persistance des données
+
+Un service `DataService` centralise toutes les opérations de lecture et d'écriture vers les tables Supabase. Chaque fonctionnalité de l'application utilise ce service pour manipuler les agents, les tâches, les incidents, le planning ou les messages. Les modifications sont donc sauvegardées de façon permanente dans Supabase.

--- a/src/components/Dashboard/AgentManager.tsx
+++ b/src/components/Dashboard/AgentManager.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Agent } from '../../types';
+
+const emptyForm: Omit<Agent, 'id'> = {
+  prenom: '',
+  nom: '',
+  poste: '',
+  telephone: '',
+  email: '',
+};
+
+const AgentManager: React.FC = () => {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [form, setForm] = useState<Omit<Agent, 'id'>>(emptyForm);
+
+  const loadAgents = () => {
+    DataService.getAgents()
+      .then(setAgents)
+      .catch(() => setAgents([]));
+  };
+
+  useEffect(() => {
+    loadAgents();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await DataService.createAgent(form);
+    setForm(emptyForm);
+    loadAgents();
+  };
+
+  const handleUpdate = async (agent: Agent) => {
+    const prenom = window.prompt('Prénom', agent.prenom);
+    if (prenom === null) return;
+    const nom = window.prompt('Nom', agent.nom);
+    if (nom === null) return;
+    const poste = window.prompt('Poste', agent.poste);
+    if (poste === null) return;
+    const telephone = window.prompt('Téléphone', agent.telephone);
+    if (telephone === null) return;
+    const email = window.prompt('Email', agent.email);
+    if (email === null) return;
+    await DataService.updateAgent(agent.id, { prenom, nom, poste, telephone, email });
+    loadAgents();
+  };
+
+  const handleDelete = async (id: string) => {
+    await DataService.deleteAgent(id);
+    loadAgents();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Agents</h3>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input name="prenom" value={form.prenom} onChange={handleChange} placeholder="Prénom" className="border px-2" />
+        <input name="nom" value={form.nom} onChange={handleChange} placeholder="Nom" className="border px-2" />
+        <input name="poste" value={form.poste} onChange={handleChange} placeholder="Poste" className="border px-2" />
+        <input name="telephone" value={form.telephone} onChange={handleChange} placeholder="Téléphone" className="border px-2" />
+        <input name="email" value={form.email} onChange={handleChange} placeholder="Email" className="border px-2" />
+        <button type="submit" className="bg-green-600 text-white px-3 rounded">Ajouter</button>
+      </form>
+      <ul className="space-y-1">
+        {agents.map((a) => (
+          <li key={a.id} className="flex items-center space-x-2">
+            <span className="flex-1">{a.prenom} {a.nom} - {a.poste}</span>
+            <button onClick={() => handleUpdate(a)} className="text-blue-600">Modifier</button>
+            <button onClick={() => handleDelete(a.id)} className="text-red-600">Supprimer</button>
+          </li>
+        ))}
+        {agents.length === 0 && <li>Aucun agent</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default AgentManager;

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { AuthService } from '../../services/authService';
 import { User } from '../../types';
+import AgentManager from './AgentManager';
+import TaskManager from './TaskManager';
+import IncidentManager from './IncidentManager';
+import PlanningManager from './PlanningManager';
+import MessageManager from './MessageManager';
+import ParamManager from './ParamManager';
 
 interface DashboardProps {
   user: User;
@@ -22,6 +28,14 @@ const Dashboard: React.FC<DashboardProps> = ({ user }) => {
       >
         Se déconnecter
       </button>
+      <div className="space-y-8 mt-6">
+        <AgentManager />
+        <TaskManager />
+        <IncidentManager />
+        <PlanningManager />
+        <MessageManager />
+        <ParamManager />
+      </div>
     </div>
   );
 };

--- a/src/components/Dashboard/IncidentManager.tsx
+++ b/src/components/Dashboard/IncidentManager.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Incident } from '../../types';
+
+const emptyForm: Omit<Incident, 'id'> = {
+  titre: '',
+};
+
+const IncidentManager: React.FC = () => {
+  const [incidents, setIncidents] = useState<Incident[]>([]);
+  const [form, setForm] = useState<Omit<Incident, 'id'>>(emptyForm);
+
+  const loadIncidents = () => {
+    DataService.getIncidents().then(setIncidents).catch(() => setIncidents([]));
+  };
+
+  useEffect(() => {
+    loadIncidents();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await DataService.createIncident(form);
+    setForm(emptyForm);
+    loadIncidents();
+  };
+
+  const handleUpdate = async (inc: Incident) => {
+    const titre = window.prompt('Titre', inc.titre);
+    if (titre === null) return;
+    await DataService.updateIncident(inc.id, { titre });
+    loadIncidents();
+  };
+
+  const handleDelete = async (id: string) => {
+    await DataService.deleteIncident(id);
+    loadIncidents();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Incidents</h3>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input name="titre" value={form.titre} onChange={handleChange} placeholder="Titre" className="border px-2" />
+        <button type="submit" className="bg-green-600 text-white px-3 rounded">Ajouter</button>
+      </form>
+      <ul className="space-y-1">
+        {incidents.map((i) => (
+          <li key={i.id} className="flex items-center space-x-2">
+            <span className="flex-1">{i.titre}</span>
+            <button onClick={() => handleUpdate(i)} className="text-blue-600">Modifier</button>
+            <button onClick={() => handleDelete(i.id)} className="text-red-600">Supprimer</button>
+          </li>
+        ))}
+        {incidents.length === 0 && <li>Aucun incident</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default IncidentManager;

--- a/src/components/Dashboard/MessageManager.tsx
+++ b/src/components/Dashboard/MessageManager.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Message } from '../../types';
+
+const emptyForm: Omit<Message, 'id'> = {
+  auteur: '',
+  contenu: '',
+  destinataire: '',
+  date: '',
+};
+
+const MessageManager: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [form, setForm] = useState<Omit<Message, 'id'>>(emptyForm);
+
+  const loadMessages = () => {
+    DataService.getMessages().then(setMessages).catch(() => setMessages([]));
+  };
+
+  useEffect(() => {
+    loadMessages();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await DataService.createMessage(form);
+    setForm(emptyForm);
+    loadMessages();
+  };
+
+  const handleDelete = async (id: string) => {
+    await DataService.deleteMessage(id);
+    loadMessages();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Messages</h3>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input name="auteur" value={form.auteur} onChange={handleChange} placeholder="Auteur" className="border px-2" />
+        <input name="destinataire" value={form.destinataire} onChange={handleChange} placeholder="Destinataire" className="border px-2" />
+        <input name="contenu" value={form.contenu} onChange={handleChange} placeholder="Contenu" className="border px-2" />
+        <input name="date" value={form.date} onChange={handleChange} placeholder="Date" className="border px-2" />
+        <button type="submit" className="bg-green-600 text-white px-3 rounded">Ajouter</button>
+      </form>
+      <ul className="space-y-1">
+        {messages.map((m) => (
+          <li key={m.id} className="flex items-center space-x-2">
+            <span className="flex-1">{m.auteur} → {m.destinataire}: {m.contenu}</span>
+            <button onClick={() => handleDelete(m.id)} className="text-red-600">Supprimer</button>
+          </li>
+        ))}
+        {messages.length === 0 && <li>Aucun message</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default MessageManager;

--- a/src/components/Dashboard/ParamManager.tsx
+++ b/src/components/Dashboard/ParamManager.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Parametre } from '../../types';
+
+const ParamManager: React.FC = () => {
+  const [params, setParams] = useState<Parametre[]>([]);
+
+  const loadParams = () => {
+    DataService.getParametres().then(setParams).catch(() => setParams([]));
+  };
+
+  useEffect(() => {
+    loadParams();
+  }, []);
+
+  const handleUpdate = async (p: Parametre) => {
+    const valeur = window.prompt(`Valeur pour ${p.nom}`, p.valeur);
+    if (valeur === null) return;
+    await DataService.updateParametre(p.nom, valeur);
+    loadParams();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Paramètres</h3>
+      <ul className="space-y-1">
+        {params.map((p) => (
+          <li key={p.nom} className="flex items-center space-x-2">
+            <span className="flex-1">{p.nom}: {p.valeur}</span>
+            <button onClick={() => handleUpdate(p)} className="text-blue-600">Modifier</button>
+          </li>
+        ))}
+        {params.length === 0 && <li>Aucun paramètre</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default ParamManager;

--- a/src/components/Dashboard/PlanningManager.tsx
+++ b/src/components/Dashboard/PlanningManager.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Planning } from '../../types';
+
+const emptyForm: Omit<Planning, 'id'> = {
+  jour: '',
+  horaire_debut: '',
+  horaire_fin: '',
+};
+
+const PlanningManager: React.FC = () => {
+  const [plannings, setPlannings] = useState<Planning[]>([]);
+  const [form, setForm] = useState<Omit<Planning, 'id'>>(emptyForm);
+
+  const loadPlannings = () => {
+    DataService.getPlannings().then(setPlannings).catch(() => setPlannings([]));
+  };
+
+  useEffect(() => {
+    loadPlannings();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await DataService.createPlanning(form);
+    setForm(emptyForm);
+    loadPlannings();
+  };
+
+  const handleUpdate = async (p: Planning) => {
+    const jour = window.prompt('Jour', p.jour);
+    if (jour === null) return;
+    const horaire_debut = window.prompt('Début', p.horaire_debut);
+    if (horaire_debut === null) return;
+    const horaire_fin = window.prompt('Fin', p.horaire_fin);
+    if (horaire_fin === null) return;
+    await DataService.updatePlanning(p.id, { jour, horaire_debut, horaire_fin });
+    loadPlannings();
+  };
+
+  const handleDelete = async (id: string) => {
+    await DataService.deletePlanning(id);
+    loadPlannings();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Planning</h3>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input name="jour" value={form.jour} onChange={handleChange} placeholder="Jour" className="border px-2" />
+        <input name="horaire_debut" value={form.horaire_debut} onChange={handleChange} placeholder="Début" className="border px-2" />
+        <input name="horaire_fin" value={form.horaire_fin} onChange={handleChange} placeholder="Fin" className="border px-2" />
+        <button type="submit" className="bg-green-600 text-white px-3 rounded">Ajouter</button>
+      </form>
+      <ul className="space-y-1">
+        {plannings.map((p) => (
+          <li key={p.id} className="flex items-center space-x-2">
+            <span className="flex-1">{p.jour} {p.horaire_debut}-{p.horaire_fin}</span>
+            <button onClick={() => handleUpdate(p)} className="text-blue-600">Modifier</button>
+            <button onClick={() => handleDelete(p.id)} className="text-red-600">Supprimer</button>
+          </li>
+        ))}
+        {plannings.length === 0 && <li>Aucun planning</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default PlanningManager;

--- a/src/components/Dashboard/TaskManager.tsx
+++ b/src/components/Dashboard/TaskManager.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { DataService } from '../../services/dataService';
+import { Task } from '../../types';
+
+const emptyForm: Omit<Task, 'id'> = {
+  titre: '',
+  description: '',
+};
+
+const TaskManager: React.FC = () => {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [form, setForm] = useState<Omit<Task, 'id'>>(emptyForm);
+
+  const loadTasks = () => {
+    DataService.getTasks().then(setTasks).catch(() => setTasks([]));
+  };
+
+  useEffect(() => {
+    loadTasks();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await DataService.createTask(form);
+    setForm(emptyForm);
+    loadTasks();
+  };
+
+  const handleUpdate = async (task: Task) => {
+    const titre = window.prompt('Titre', task.titre);
+    if (titre === null) return;
+    const description = window.prompt('Description', task.description || '');
+    if (description === null) return;
+    await DataService.updateTask(task.id, { titre, description });
+    loadTasks();
+  };
+
+  const handleDelete = async (id: string) => {
+    await DataService.deleteTask(id);
+    loadTasks();
+  };
+
+  return (
+    <div className="mb-10">
+      <h3 className="text-xl font-semibold mb-2">Tâches</h3>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input name="titre" value={form.titre} onChange={handleChange} placeholder="Titre" className="border px-2" />
+        <input name="description" value={form.description} onChange={handleChange} placeholder="Description" className="border px-2" />
+        <button type="submit" className="bg-green-600 text-white px-3 rounded">Ajouter</button>
+      </form>
+      <ul className="space-y-1">
+        {tasks.map((t) => (
+          <li key={t.id} className="flex items-center space-x-2">
+            <span className="flex-1">{t.titre}</span>
+            <button onClick={() => handleUpdate(t)} className="text-blue-600">Modifier</button>
+            <button onClick={() => handleDelete(t.id)} className="text-red-600">Supprimer</button>
+          </li>
+        ))}
+        {tasks.length === 0 && <li>Aucune tâche</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskManager;

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,0 +1,165 @@
+import { supabase } from './supabaseClient';
+import { Agent, Task, Incident, Planning, Message, Parametre } from '../types';
+
+export class DataService {
+  // Agents
+  static async getAgents(): Promise<Agent[]> {
+    const { data, error } = await supabase.from('agents').select('*').order('id');
+    if (error) throw error;
+    return data as Agent[];
+  }
+
+  static async createAgent(agent: Omit<Agent, 'id'>): Promise<Agent> {
+    const { data, error } = await supabase
+      .from('agents')
+      .insert(agent)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as Agent;
+  }
+
+  static async updateAgent(id: string, updates: Partial<Agent>): Promise<Agent | null> {
+    const { data, error } = await supabase
+      .from('agents')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    return data as Agent | null;
+  }
+
+  static async deleteAgent(id: string): Promise<void> {
+    const { error } = await supabase.from('agents').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // Tasks
+  static async getTasks(): Promise<Task[]> {
+    const { data, error } = await supabase.from('tasks').select('*').order('id');
+    if (error) throw error;
+    return data as Task[];
+  }
+
+  static async createTask(task: Omit<Task, 'id'>): Promise<Task> {
+    const { data, error } = await supabase.from('tasks').insert(task).select().single();
+    if (error) throw error;
+    return data as Task;
+  }
+
+  static async updateTask(id: string, updates: Partial<Task>): Promise<Task | null> {
+    const { data, error } = await supabase
+      .from('tasks')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    return data as Task | null;
+  }
+
+  static async deleteTask(id: string): Promise<void> {
+    const { error } = await supabase.from('tasks').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // Incidents
+  static async getIncidents(): Promise<Incident[]> {
+    const { data, error } = await supabase.from('incidents').select('*').order('id');
+    if (error) throw error;
+    return data as Incident[];
+  }
+
+  static async createIncident(incident: Omit<Incident, 'id'>): Promise<Incident> {
+    const { data, error } = await supabase
+      .from('incidents')
+      .insert(incident)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as Incident;
+  }
+
+  static async updateIncident(id: string, updates: Partial<Incident>): Promise<Incident | null> {
+    const { data, error } = await supabase
+      .from('incidents')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    return data as Incident | null;
+  }
+
+  static async deleteIncident(id: string): Promise<void> {
+    const { error } = await supabase.from('incidents').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // Planning
+  static async getPlannings(): Promise<Planning[]> {
+    const { data, error } = await supabase.from('plannings').select('*').order('id');
+    if (error) throw error;
+    return data as Planning[];
+  }
+
+  static async createPlanning(planning: Omit<Planning, 'id'>): Promise<Planning> {
+    const { data, error } = await supabase
+      .from('plannings')
+      .insert(planning)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as Planning;
+  }
+
+  static async updatePlanning(id: string, updates: Partial<Planning>): Promise<Planning | null> {
+    const { data, error } = await supabase
+      .from('plannings')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    return data as Planning | null;
+  }
+
+  static async deletePlanning(id: string): Promise<void> {
+    const { error } = await supabase.from('plannings').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // Messages
+  static async getMessages(): Promise<Message[]> {
+    const { data, error } = await supabase.from('messages').select('*').order('id');
+    if (error) throw error;
+    return data as Message[];
+  }
+
+  static async createMessage(message: Omit<Message, 'id'>): Promise<Message> {
+    const { data, error } = await supabase.from('messages').insert(message).select().single();
+    if (error) throw error;
+    return data as Message;
+  }
+
+  static async deleteMessage(id: string): Promise<void> {
+    const { error } = await supabase.from('messages').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // Parametres
+  static async getParametres(): Promise<Parametre[]> {
+    const { data, error } = await supabase.from('parametres').select('*').order('nom');
+    if (error) throw error;
+    return data as Parametre[];
+  }
+
+  static async updateParametre(nom: string, valeur: string): Promise<void> {
+    const { error } = await supabase
+      .from('parametres')
+      .update({ valeur })
+      .eq('nom', nom);
+    if (error) throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- replace AgentList with full CRUD manager
- add managers for tasks, incidents, planning, messages and parameters
- hook managers into the dashboard
- ensure persistence through DataService

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cd375159c83239be8a5f119f1ae3e